### PR TITLE
es6 support

### DIFF
--- a/src/app/components/settings.js
+++ b/src/app/components/settings.js
@@ -13,6 +13,7 @@ function (_) {
       elasticsearch     : "http://"+window.location.hostname+":9200",
       panel_names       : [],
       kibana_index      : 'kibana-int',
+      kibana_temp_index : 'kibana-int-temp',
       default_route     : '/dashboard/file/default.json'
     };
 

--- a/src/app/services/dashboard.js
+++ b/src/app/services/dashboard.js
@@ -374,9 +374,18 @@ function (angular, $, kbn, _, config, moment, Modernizr) {
       // Previously threre was unix timestamp value query param at the end
       // Looks like it is not needed at all
       // ES5 claims on unsupported prams, thus removed it
-      ejs.client.get(
-        "/" + config.kibana_index + "/"+type+"/" + id,
-        null, successcb, errorcb);
+      switch(type){
+        case('dashboard'):
+          ejs.client.get(
+            "/" + config.kibana_index + "/"+type+"/" + id,
+            null, successcb, errorcb);
+          break;
+        case('temp'):
+          ejs.client.get(
+            "/" + config.kibana_temp_index + "/"+type+"/" + id,
+            null, successcb, errorcb);
+          break;
+      }
 
     };
 
@@ -414,7 +423,7 @@ function (angular, $, kbn, _, config, moment, Modernizr) {
       }
 
       // Create request with id as title. Rethink this.
-      var request = ejs.Document(config.kibana_index,type,id).source({
+     var request = ejs.Document(type === 'temp' ? config.kibana_temp_index : config.kibana_index,type,id).source({
         user: 'guest',
         group: 'guest',
         title: save.title,

--- a/src/app/services/kbnIndex.js
+++ b/src/app/services/kbnIndex.js
@@ -40,7 +40,7 @@ function (angular, _, config, moment) {
       // Previously there was `ignore_missing=true` query param
       // Looks like it did nothing
       // Also it is deprecated and not supported by ES5, thus removed
-      something = ejs.client.get("/" + indices.join(",") + "/_aliases?ignore_unavailable=true",
+      something = ejs.client.get("/_all/_alias?ignore_unavailable=true",
         undefined, undefined, function (data, p) {
           if (p === 404) {
             return [];

--- a/src/config.js
+++ b/src/config.js
@@ -67,6 +67,7 @@ define(['settings'],
        * such as stored dashboards
        */
       kibana_index: "kibana",
+      kibana_temp_index: "kibana-temp",
       // kibana_index: "kibana-int",
 
       /** @scratch /configuration/config.js/5

--- a/src/vendor/elasticjs/elastic.js
+++ b/src/vendor/elasticjs/elastic.js
@@ -8506,7 +8506,7 @@
           return params.ttl;
         }
 
-        params.ttl = length;
+        //params.ttl = length;
         return this;
       },
 


### PR DESCRIPTION
* _aliases doesn't work on a list of indices, just use _all
* ttl is no longer supported; silently ignore it
* indices no longer support multiple types; use a temp index for sharing